### PR TITLE
Erase statement that gives away answer

### DIFF
--- a/lab04/lab04.ipynb
+++ b/lab04/lab04.ipynb
@@ -254,7 +254,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "What have we gained?  Well, without the function, we'd have to copy that `10**6 * float(pay_string.strip(\"$\"))` stuff each time we wanted to convert a pay string.  Now we just call a function whose name says exactly what it's doing.\n",
+    "What have we gained?  Well, without the function, we'd have to copy or rewrite that line of code each time we wanted to convert a pay string.  Now we just call a function whose name says exactly what it's doing.\n",
     "\n",
     "Soon, we'll see how to apply this function to every pay string in a single expression. First, let's write some more functions."
    ]


### PR DESCRIPTION
Erase statement that gave away a possible answer and put something more generic instead. Another slight problem with the statement is that it frames that answer as "the" answer when in fact there are several possible answers.